### PR TITLE
Created a linter rule that disallows adding cross-package imports in the ckeditor5-watchdog package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,11 @@ module.exports = {
 		'ckeditor5-rules',
 		'mocha'
 	],
+	settings:{
+		disallowedCrossImportsPackages:[
+			'ckeditor5-watchdog'
+		]
+	},
 	rules: {
 		// ## Possible errors
 		// Offing because we keep the browser env disabled so when using a console you need to define
@@ -299,6 +304,7 @@ module.exports = {
 		],
 		'ckeditor5-rules/no-relative-imports': 'error',
 		'ckeditor5-rules/ckeditor-error-message': 'error',
+		'ckeditor5-rules/no-cross-package-imports': 'error',
 		'mocha/handle-done-callback': 'error',
 		'mocha/no-async-describe': 'error',
 		'mocha/no-exclusive-tests': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,8 +23,8 @@ module.exports = {
 		'ckeditor5-rules',
 		'mocha'
 	],
-	settings:{
-		disallowedCrossImportsPackages:[
+	settings: {
+		disallowedCrossImportsPackages: [
 			'ckeditor5-watchdog'
 		]
 	},

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 yarn.lock
+node_modules


### PR DESCRIPTION
Other: Enabled the `ckeditor5-rules/no-cross-package-imports` rule that disallows importing modules from CKEditor 5 packages inside the `@ckeditor/ckeditor5-watchdog` package. See: ckeditor/ckeditor5#9318.